### PR TITLE
Added support for 'epic' label type

### DIFF
--- a/src/Yandex/Allure/Adapter/Annotation/AnnotationManager.php
+++ b/src/Yandex/Allure/Adapter/Annotation/AnnotationManager.php
@@ -75,6 +75,10 @@ class AnnotationManager
                     $annotation->value,
                     $annotation->kind
                 );
+            } elseif ($annotation instanceof Epics) {
+                foreach ($annotation->getEpicNames() as $epicName) {
+                    $this->labels[] = Model\Label::epic($epicName);
+                }
             }
         }
     }

--- a/src/Yandex/Allure/Adapter/Annotation/Epics.php
+++ b/src/Yandex/Allure/Adapter/Annotation/Epics.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yandex\Allure\Adapter\Annotation;
+
+use Doctrine\Common\Annotations\Annotation\Required;
+
+/**
+ * @Annotation
+ * @Target({"CLASS", "METHOD"})
+ * @package Yandex\Allure\Adapter\Annotation
+ */
+class Epics
+{
+    /**
+     * @var array
+     * @Required
+     */
+    public $epicNames;
+
+    /**
+     * @return array
+     */
+    public function getEpicNames()
+    {
+        return $this->epicNames;
+    }
+}

--- a/src/Yandex/Allure/Adapter/Model/Label.php
+++ b/src/Yandex/Allure/Adapter/Model/Label.php
@@ -50,6 +50,15 @@ class Label implements Entity
     }
 
     /**
+     * @param $epicName
+     * @return Label
+     */
+    public static function epic($epicName)
+    {
+        return new Label(LabelType::EPIC, $epicName);
+    }
+
+    /**
      * @param $featureName
      * @return Label
      */
@@ -75,7 +84,7 @@ class Label implements Entity
     {
         return new Label(LabelType::SEVERITY, $severityLevel);
     }
-
+    
     /**
      * @param $testType
      * @return Label
@@ -103,5 +112,5 @@ class Label implements Entity
     {
         return new Label(LabelType::TEST_ID, $testCaseId);
     }
-
+    
 }

--- a/src/Yandex/Allure/Adapter/Model/LabelType.php
+++ b/src/Yandex/Allure/Adapter/Model/LabelType.php
@@ -10,4 +10,5 @@ class LabelType
     const ISSUE = 'issue';
     const TEST_ID = 'testId';
     const TEST_TYPE = 'testType';
+    const EPIC = 'epic';
 }


### PR DESCRIPTION
To fully exploit the reporting capabilities of Allure I've added support for the 'epic' label type. This is related to another pull request on allure-behat.