### PR TITLE
Add support for group annotations on class and methods

### DIFF
--- a/src/Yandex/Allure/Adapter/Annotation/AnnotationManager.php
+++ b/src/Yandex/Allure/Adapter/Annotation/AnnotationManager.php
@@ -83,6 +83,8 @@ class AnnotationManager
                         $parameter->kind
                     );
                 }
+            } elseif ($annotation instanceof Group) {
+                $this->labels[] = Model\Label::groupName($annotation->groupName);
             }
         }
     }

--- a/src/Yandex/Allure/Adapter/Annotation/Group.php
+++ b/src/Yandex/Allure/Adapter/Annotation/Group.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yandex\Allure\Adapter\Annotation;
+
+use Doctrine\Common\Annotations\Annotation\Required;
+
+/**
+ * @Annotation
+ * @Target({"CLASS", "METHOD"})
+ * @package Yandex\Allure\Adapter\Annotation
+ */
+class Group
+{
+    /**
+     * @var string
+     * @Required
+     */
+    public $groupName;
+
+    /**
+     * @return string
+     */
+    public function getGroupName()
+    {
+        return $this->groupName;
+    }
+}

--- a/src/Yandex/Allure/Adapter/Model/Label.php
+++ b/src/Yandex/Allure/Adapter/Model/Label.php
@@ -104,4 +104,14 @@ class Label implements Entity
         return new Label(LabelType::TEST_ID, $testCaseId);
     }
 
+    /**
+     * @param $group
+     *
+     * @return Label
+     */
+    public static function groupName($group)
+    {
+        return new Label(LabelType::GROUP, $group);
+    }
+
 }

--- a/src/Yandex/Allure/Adapter/Model/LabelType.php
+++ b/src/Yandex/Allure/Adapter/Model/LabelType.php
@@ -10,4 +10,5 @@ class LabelType
     const ISSUE = 'issue';
     const TEST_ID = 'testId';
     const TEST_TYPE = 'testType';
+    const GROUP = 'group';
 }


### PR DESCRIPTION
Add support of group annotations.

Requirement:
We've tagged each tests with relevant groups. We'd like to filter/ categorise/ see test belonging to a group, together. I see that we don't pass group information to xmls. Can we add it as a feature?

/**

Tests if this works
@group Basic_Test
@group Login
@group Logout
*/
class ThisIsATest extends BaseTest {
}

https://github.com/allure-framework/allure-php-commons/issues/48