### PR TITLE
Dropping PHP versions before 7.1.3 and Symfony versions before 4.3 to fix #61

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,24 @@ on:
       - 'master'
 
 jobs:
+  build71:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.1.3'
+      - name: Install
+        run: composer update
+      - name: Test
+        run: composer test
   build72:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2.5'
+          php-version: '7.2'
       - name: Install
         run: composer update
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,46 @@ on:
       - 'master'
 
 jobs:
-  build:
+  build72:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.2.5'
+      - name: Install
+        run: composer install
+      - name: Test
+        run: composer test
+  build73:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.3'
+      - name: Install
+        run: composer install
+      - name: Test
+        run: composer test
+  build74:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+      - name: Install
+        run: composer install
+      - name: Test
+        run: composer test
+  build80:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
       - name: Install
         run: composer install
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install
         run: composer update
       - name: Test
-        run: composer test
+        run: composer test-legacy
   build72:
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +30,7 @@ jobs:
       - name: Install
         run: composer update
       - name: Test
-        run: composer test
+        run: composer test-legacy
   build73:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           php-version: '7.2.5'
       - name: Install
-        run: composer install
+        run: composer update
       - name: Test
         run: composer test
   build73:
@@ -28,7 +28,7 @@ jobs:
         with:
           php-version: '7.3'
       - name: Install
-        run: composer install
+        run: composer update
       - name: Test
         run: composer test
   build74:
@@ -39,7 +39,7 @@ jobs:
         with:
           php-version: '7.4'
       - name: Install
-        run: composer install
+        run: composer update
       - name: Test
         run: composer test
   build80:
@@ -50,6 +50,6 @@ jobs:
         with:
           php-version: '8.0'
       - name: Install
-        run: composer install
+        run: composer update
       - name: Test
         run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ nbproject
 vendor/*
 composer.phar
 /composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
         }
     },
     "scripts": {
-        "test": [
-            "vendor/bin/phpunit test"
-        ]
+        "test": "vendor/bin/phpunit",
+        "test-legacy": "vendor/bin/phpunit --configuration=phpunit.legacy.xml"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "php": ">=7.2.5",
         "jms/serializer": "^1 | ^2 | ^3",
         "ramsey/uuid": "^3 | ^4",
-        "symfony/http-foundation": "^5.1",
         "symfony/mime": "^5.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/mime": "^5.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8"
+        "phpunit/phpunit": "^8 | ^9"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         "source": "https://github.com/allure-framework/allure-php-api"
     },
     "require": {
-        "php": ">=5.4.0",
-        "jms/serializer": "^0.16 | ^1 | ^3",
+        "php": ">=7.2.5",
+        "jms/serializer": "^1 | ^2 | ^3",
         "ramsey/uuid": "^3 | ^4",
-        "symfony/http-foundation": "^2 | ^3 | ^4 | ^5"
+        "symfony/http-foundation": "^5.1",
+        "symfony/mime": "^5.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5.15",
-        "symfony/mime": "^5"
+        "phpunit/phpunit": "^8"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         "source": "https://github.com/allure-framework/allure-php-api"
     },
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=7.1.3",
         "jms/serializer": "^1 | ^2 | ^3",
         "ramsey/uuid": "^3 | ^4",
-        "symfony/mime": "^5.1"
+        "symfony/mime": "^4.3 | ^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8 | ^9"
+        "phpunit/phpunit": "^7 | ^8 | ^9"
     },
     "autoload": {
         "psr-0": {

--- a/phpunit.legacy.xml
+++ b/phpunit.legacy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
         bootstrap="phpunit.php"
         colors="true"
         defaultTestSuite="Allure PHP API Tests">
@@ -10,9 +10,9 @@
             <directory>test/Yandex/Allure/Adapter/</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
+    <filter>
+        <whitelist>
             <directory>src/</directory>
-        </include>
-    </coverage>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
         bootstrap="phpunit.php"
         colors="true">
     <testsuites>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         bootstrap="phpunit.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
-        >
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
+        bootstrap="phpunit.php"
+        colors="true">
     <testsuites>
         <testsuite name="Allure PHP API Tests">
             <directory>test/Yandex/Allure/Adapter/</directory>

--- a/src/Yandex/Allure/Adapter/Event/AddAttachmentEvent.php
+++ b/src/Yandex/Allure/Adapter/Event/AddAttachmentEvent.php
@@ -2,8 +2,7 @@
 
 namespace Yandex\Allure\Adapter\Event;
 
-use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
-use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
+use Symfony\Component\Mime\MimeTypes;
 use Yandex\Allure\Adapter\AllureException;
 use Yandex\Allure\Adapter\Model\Attachment;
 use Yandex\Allure\Adapter\Model\Entity;
@@ -67,37 +66,14 @@ class AddAttachmentEvent implements StepEvent
 
     private function guessFileMimeType($filePath)
     {
-        $mimeTypesClass = '\Symfony\Component\Mime\MimeTypes';
-        if (class_exists($mimeTypesClass)) {
-            /** @var \Symfony\Component\Mime\MimeTypes $mimeTypes */
-            $mimeTypes = call_user_func([$mimeTypesClass, 'getDefault']);
-            $type = $mimeTypes->guessMimeType($filePath);
-        } else {
-            $type = MimeTypeGuesser::getInstance()->guess($filePath);
-        }
-        if (!isset($type)) {
-            return DEFAULT_MIME_TYPE;
-        }
-
-        return $type;
+        return MimeTypes::getDefault()->guessMimeType($filePath) ?? DEFAULT_MIME_TYPE;
     }
 
     private function guessFileExtension($mimeType)
     {
-        $mimeTypesClass = '\Symfony\Component\Mime\MimeTypes';
-        if (class_exists($mimeTypesClass)) {
-            /** @var \Symfony\Component\Mime\MimeTypes $mimeTypes */
-            $mimeTypes = call_user_func([$mimeTypesClass, 'getDefault']);
-            $extensions = $mimeTypes->getExtensions($mimeType);
-            $candidate = isset($extensions[0]) ? $extensions[0] : null;
-        } else {
-            $candidate = ExtensionGuesser::getInstance()->guess($mimeType);
-        }
-        if (!isset($candidate)) {
-            return DEFAULT_FILE_EXTENSION;
-        }
+        $extensions = MimeTypes::getDefault()->getExtensions($mimeType);
 
-        return $candidate;
+        return $extensions[0] ?? DEFAULT_FILE_EXTENSION;
     }
 
     public function getOutputFileName($sha1, $extension)

--- a/test/Yandex/Allure/Adapter/Annotation/AnnotationManagerTest.php
+++ b/test/Yandex/Allure/Adapter/Annotation/AnnotationManagerTest.php
@@ -13,7 +13,7 @@ use Yandex\Allure\Adapter\Model\LabelType;
 
 class AnnotationManagerTest extends TestCase
 {
-    public function testUpdateTestSuiteStartedEvent()
+    public function testUpdateTestSuiteStartedEvent(): void
     {
         $instance = new Fixtures\ExampleTestSuite();
         $testSuiteAnnotations = AnnotationProvider::getClassAnnotations($instance);
@@ -68,7 +68,7 @@ class AnnotationManagerTest extends TestCase
 
     }
 
-    public function testUpdateTestCaseStartedEvent()
+    public function testUpdateTestCaseStartedEvent(): void
     {
         $instance = new Fixtures\ExampleTestSuite();
         $testCaseAnnotations = AnnotationProvider::getMethodAnnotations($instance, 'exampleTestCase');
@@ -157,12 +157,7 @@ class AnnotationManagerTest extends TestCase
         $this->assertSame(ParameterKind::ARGUMENT, $parameter->getKind());
     }
 
-    /**
-     * @param array $labels
-     * @param string $labelType
-     * @return array
-     */
-    private function getLabelsByType(array $labels, $labelType)
+    private function getLabelsByType(array $labels, string $labelType): array
     {
         $filteredArray = array_filter(
             $labels,

--- a/test/Yandex/Allure/Adapter/Annotation/AnnotationProviderTest.php
+++ b/test/Yandex/Allure/Adapter/Annotation/AnnotationProviderTest.php
@@ -2,26 +2,27 @@
 
 namespace Yandex\Allure\Adapter\Annotation;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use PHPUnit\Framework\TestCase;
 
 class AnnotationProviderTest extends TestCase
 {
-    const TYPE_CLASS = 'class';
-    const TYPE_METHOD = 'method';
-    const METHOD_NAME = 'methodWithAnnotations';
+    private const TYPE_CLASS = 'class';
+    private const TYPE_METHOD = 'method';
+    private const METHOD_NAME = 'methodWithAnnotations';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         AnnotationRegistry::registerFile(__DIR__ . '/Fixtures/TestAnnotation.php');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         AnnotationProvider::tearDown();
     }
 
-    public function testGetClassAnnotations()
+    public function testGetClassAnnotations(): void
     {
         $instance = new Fixtures\ClassWithAnnotations();
         $annotations = AnnotationProvider::getClassAnnotations($instance);
@@ -31,7 +32,7 @@ class AnnotationProviderTest extends TestCase
         $this->assertEquals(self::TYPE_CLASS, $annotation->value);
     }
 
-    public function testGetMethodAnnotations()
+    public function testGetMethodAnnotations(): void
     {
         $instance = new Fixtures\ClassWithAnnotations();
         $annotations = AnnotationProvider::getMethodAnnotations($instance, self::METHOD_NAME);
@@ -41,16 +42,14 @@ class AnnotationProviderTest extends TestCase
         $this->assertEquals(self::TYPE_METHOD, $annotation->value);
     }
 
-    /**
-     * @expectedException \Doctrine\Common\Annotations\AnnotationException
-     */
-    public function testShouldThrowExceptionForNotImportedAnnotations()
+    public function testShouldThrowExceptionForNotImportedAnnotations(): void
     {
         $instance = new Fixtures\ClassWithIgnoreAnnotation();
+        $this->expectException(AnnotationException::class);
         AnnotationProvider::getClassAnnotations($instance);
     }
 
-    public function testShouldIgnoreGivenAnnotations()
+    public function testShouldIgnoreGivenAnnotations(): void
     {
         $instance = new Fixtures\ClassWithIgnoreAnnotation();
         AnnotationProvider::addIgnoredAnnotations(['SomeCustomClassAnnotation', 'SomeCustomMethodAnnotation']);

--- a/test/Yandex/Allure/Adapter/Event/AddAttachmentEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/AddAttachmentEventTest.php
@@ -8,9 +8,9 @@ use Yandex\Allure\Adapter\Model\Step;
 
 class AddAttachmentEventTest extends TestCase
 {
-    const ATTACHMENT_CAPTION = 'test-caption';
+    private const ATTACHMENT_CAPTION = 'test-caption';
 
-    public function testEventWithFile()
+    public function testEventWithFile(): void
     {
         $attachmentCaption = self::ATTACHMENT_CAPTION;
         $attachmentType = 'application/json';
@@ -36,7 +36,7 @@ class AddAttachmentEventTest extends TestCase
         );
     }
 
-    public function testEventWithStringContents()
+    public function testEventWithStringContents(): void
     {
         $attachmentCaption = self::ATTACHMENT_CAPTION;
         $attachmentType = 'text/plain';
@@ -67,7 +67,7 @@ class AddAttachmentEventTest extends TestCase
         $attachmentFileName,
         $attachmentCaption,
         $attachmentType
-    ) {
+    ): void {
         $this->assertTrue(file_exists($attachmentOutputPath));
         $attachments = $step->getAttachments();
         $this->assertEquals(1, sizeof($attachments));
@@ -78,7 +78,7 @@ class AddAttachmentEventTest extends TestCase
         $this->assertEquals($attachmentType, $attachment->getType());
     }
 
-    private function getTestContents()
+    private function getTestContents(): string
     {
         return str_shuffle('test-contents');
     }

--- a/test/Yandex/Allure/Adapter/Event/AddParameterEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/AddParameterEventTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase as PhpUnitTestCase;
 
 class AddParameterEventTest extends PhpUnitTestCase
 {
-    public function testEvent()
+    public function testEvent(): void
     {
         $parameterName = 'test-name';
         $parameterValue = 'test-value';

--- a/test/Yandex/Allure/Adapter/Event/RemoveAttachmentsEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/RemoveAttachmentsEventTest.php
@@ -6,11 +6,12 @@ use PHPUnit\Framework\TestCase;
 use Yandex\Allure\Adapter\Model\Attachment;
 use Yandex\Allure\Adapter\Model\Step;
 
-const ATTACHMENT_TYPE = 'text/plain';
 
 class RemoveAttachmentsEventTest extends TestCase
 {
-    public function testLifecycle()
+    private const ATTACHMENT_TYPE = 'text/plain';
+
+    public function testLifecycle(): void
     {
         $attachmentTitle = 'some-title';
         $pattern = 'matching';
@@ -22,8 +23,8 @@ class RemoveAttachmentsEventTest extends TestCase
         $notMatchingFilename = tempnam($tmpDirectory, 'excluded');
 
         $step = new Step();
-        $step->addAttachment(new Attachment($attachmentTitle, $matchingFilename, ATTACHMENT_TYPE));
-        $step->addAttachment(new Attachment($attachmentTitle, $notMatchingFilename, ATTACHMENT_TYPE));
+        $step->addAttachment(new Attachment($attachmentTitle, $matchingFilename, self::ATTACHMENT_TYPE));
+        $step->addAttachment(new Attachment($attachmentTitle, $notMatchingFilename, self::ATTACHMENT_TYPE));
 
         $this->assertEquals(2, sizeof($step->getAttachments()));
 

--- a/test/Yandex/Allure/Adapter/Event/StepCanceledEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/StepCanceledEventTest.php
@@ -6,18 +6,12 @@ use Yandex\Allure\Adapter\Model\Status;
 
 class StepCanceledEventTest extends StepStatusChangedEventTest
 {
-    /**
-     * @return string
-     */
-    protected function getTestedStatus()
+    protected function getTestedStatus(): string
     {
         return Status::CANCELED;
     }
 
-    /**
-     * @return StepEvent
-     */
-    protected function getStepEvent()
+    protected function getStepEvent(): StepEvent
     {
         return new StepCanceledEvent();
     }

--- a/test/Yandex/Allure/Adapter/Event/StepFailedEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/StepFailedEventTest.php
@@ -6,18 +6,12 @@ use Yandex\Allure\Adapter\Model\Status;
 
 class StepFailedEventTest extends StepStatusChangedEventTest
 {
-    /**
-     * @return string
-     */
-    protected function getTestedStatus()
+    protected function getTestedStatus(): string
     {
         return Status::FAILED;
     }
 
-    /**
-     * @return StepEvent
-     */
-    protected function getStepEvent()
+    protected function getStepEvent(): StepEvent
     {
         return new StepFailedEvent();
     }

--- a/test/Yandex/Allure/Adapter/Event/StepFinishedEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/StepFinishedEventTest.php
@@ -7,7 +7,7 @@ use Yandex\Allure\Adapter\Model\Step;
 
 class StepFinishedEventTest extends TestCase
 {
-    public function testEvent()
+    public function testEvent(): void
     {
         $step = new Step();
         $event = new StepFinishedEvent();

--- a/test/Yandex/Allure/Adapter/Event/StepStartedEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/StepStartedEventTest.php
@@ -8,7 +8,7 @@ use Yandex\Allure\Adapter\Model\Step;
 
 class StepStartedEventTest extends TestCase
 {
-    public function testEvent()
+    public function testEvent(): void
     {
         $step = new Step();
         $stepName = 'step-name';

--- a/test/Yandex/Allure/Adapter/Event/StepStatusChangedEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/StepStatusChangedEventTest.php
@@ -7,17 +7,11 @@ use Yandex\Allure\Adapter\Model\Step;
 
 abstract class StepStatusChangedEventTest extends TestCase
 {
-    /**
-     * @return string
-     */
-    abstract protected function getTestedStatus();
+    abstract protected function getTestedStatus(): string;
 
-    /**
-     * @return StepEvent
-     */
-    abstract protected function getStepEvent();
+    abstract protected function getStepEvent(): StepEvent;
 
-    public function testEvent()
+    public function testEvent(): void
     {
         $step = new Step();
         $event = $this->getStepEvent();

--- a/test/Yandex/Allure/Adapter/Event/Storage/StepStorageTest.php
+++ b/test/Yandex/Allure/Adapter/Event/Storage/StepStorageTest.php
@@ -7,9 +7,9 @@ use Yandex\Allure\Adapter\Model\Step;
 
 class StepStorageTest extends TestCase
 {
-    const TEST_STEP_NAME = 'test-step';
+    private const TEST_STEP_NAME = 'test-step';
 
-    public function testEmptyStorage()
+    public function testEmptyStorage(): void
     {
         $storage = new Fixtures\MockedRootStepStorage();
         $this->assertTrue($storage->isRootStep($storage->getLast()));
@@ -17,12 +17,12 @@ class StepStorageTest extends TestCase
         $this->assertTrue($storage->isEmpty());
     }
 
-    public function testNonEmptyStorage()
+    public function testNonEmptyStorage(): void
     {
         $storage = new Fixtures\MockedRootStepStorage();
         $step = new Step();
         $step->setName(self::TEST_STEP_NAME);
         $storage->put($step);
-        $this->assertEquals($storage->getLast()->getName(), self::TEST_STEP_NAME);
+        $this->assertEquals(self::TEST_STEP_NAME, $storage->getLast()->getName());
     }
 }

--- a/test/Yandex/Allure/Adapter/Event/Storage/TestCaseStorageTest.php
+++ b/test/Yandex/Allure/Adapter/Event/Storage/TestCaseStorageTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase as PhpUnitTestCase;
 
 class TestCaseStorageTest extends PhpUnitTestCase
 {
-    public function testLifecycle()
+    public function testLifecycle(): void
     {
         $storage = new TestCaseStorage();
         $testCase = $storage->get();

--- a/test/Yandex/Allure/Adapter/Event/Storage/TestSuiteStorageTest.php
+++ b/test/Yandex/Allure/Adapter/Event/Storage/TestSuiteStorageTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class TestSuiteStorageTest extends TestCase
 {
-    public function testLifecycle()
+    public function testLifecycle(): void
     {
         $storage = new TestSuiteStorage();
         $uuid = 'some-uuid';

--- a/test/Yandex/Allure/Adapter/Event/TestCaseBrokenEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/TestCaseBrokenEventTest.php
@@ -6,18 +6,12 @@ use Yandex\Allure\Adapter\Model\Status;
 
 class TestCaseBrokenEventTest extends TestCaseStatusChangedEventTest
 {
-    /**
-     * @return string
-     */
-    protected function getTestedStatus()
+    protected function getTestedStatus(): string
     {
         return Status::BROKEN;
     }
 
-    /**
-     * @return TestCaseStatusChangedEvent
-     */
-    protected function getTestCaseStatusChangedEvent()
+    protected function getTestCaseStatusChangedEvent(): TestCaseStatusChangedEvent
     {
         return new TestCaseBrokenEvent();
     }

--- a/test/Yandex/Allure/Adapter/Event/TestCaseCanceledEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/TestCaseCanceledEventTest.php
@@ -6,18 +6,12 @@ use Yandex\Allure\Adapter\Model\Status;
 
 class TestCaseCanceledEventTest extends TestCaseStatusChangedEventTest
 {
-    /**
-     * @return string
-     */
-    protected function getTestedStatus()
+    protected function getTestedStatus(): string
     {
         return Status::CANCELED;
     }
 
-    /**
-     * @return TestCaseStatusChangedEvent
-     */
-    protected function getTestCaseStatusChangedEvent()
+    protected function getTestCaseStatusChangedEvent(): TestCaseStatusChangedEvent
     {
         return new TestCaseCanceledEvent();
     }

--- a/test/Yandex/Allure/Adapter/Event/TestCaseFailedEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/TestCaseFailedEventTest.php
@@ -6,18 +6,12 @@ use Yandex\Allure\Adapter\Model\Status;
 
 class TestCaseFailedEventTest extends TestCaseStatusChangedEventTest
 {
-    /**
-     * @return string
-     */
-    protected function getTestedStatus()
+    protected function getTestedStatus(): string
     {
         return Status::FAILED;
     }
 
-    /**
-     * @return TestCaseStatusChangedEvent
-     */
-    protected function getTestCaseStatusChangedEvent()
+    protected function getTestCaseStatusChangedEvent(): TestCaseStatusChangedEvent
     {
         return new TestCaseFailedEvent();
     }

--- a/test/Yandex/Allure/Adapter/Event/TestCaseFinishedEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/TestCaseFinishedEventTest.php
@@ -7,7 +7,7 @@ use Yandex\Allure\Adapter\Model\TestCase;
 
 class TestCaseFinishedEventTest extends PhpUnitTestCase
 {
-    public function testEvent()
+    public function testEvent(): void
     {
         $testCase = new TestCase();
         $event = new TestCaseFinishedEvent();

--- a/test/Yandex/Allure/Adapter/Event/TestCasePendingEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/TestCasePendingEventTest.php
@@ -6,18 +6,12 @@ use Yandex\Allure\Adapter\Model\Status;
 
 class TestCasePendingEventTest extends TestCaseStatusChangedEventTest
 {
-    /**
-     * @return string
-     */
-    protected function getTestedStatus()
+    protected function getTestedStatus(): string
     {
         return Status::PENDING;
     }
 
-    /**
-     * @return TestCaseStatusChangedEvent
-     */
-    protected function getTestCaseStatusChangedEvent()
+    protected function getTestCaseStatusChangedEvent(): TestCaseStatusChangedEvent
     {
         return new TestCasePendingEvent();
     }

--- a/test/Yandex/Allure/Adapter/Event/TestCaseStartedEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/TestCaseStartedEventTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase as PhpUnitTestCase;
 
 class TestCaseStartedEventTest extends PhpUnitTestCase
 {
-    public function testEvent()
+    public function testEvent(): void
     {
         $testCase = new TestCase();
         $uuid = 'test-uuid';

--- a/test/Yandex/Allure/Adapter/Event/TestCaseStatusChangedEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/TestCaseStatusChangedEventTest.php
@@ -8,17 +8,11 @@ use PHPUnit\Framework\TestCase as PhpUnitTestCase;
 
 abstract class TestCaseStatusChangedEventTest extends PhpUnitTestCase
 {
-    /**
-     * @return string
-     */
-    abstract protected function getTestedStatus();
+    abstract protected function getTestedStatus(): string;
 
-    /**
-     * @return TestCaseStatusChangedEvent
-     */
-    abstract protected function getTestCaseStatusChangedEvent();
+    abstract protected function getTestCaseStatusChangedEvent(): TestCaseStatusChangedEvent;
 
-    public function testEvent()
+    public function testEvent(): void
     {
         $testMessage = 'test-message';
         $testCase = new TestCase();

--- a/test/Yandex/Allure/Adapter/Event/TestSuiteFinishedEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/TestSuiteFinishedEventTest.php
@@ -7,7 +7,7 @@ use Yandex\Allure\Adapter\Model\TestSuite;
 
 class TestSuiteFinishedEventTest extends TestCase
 {
-    public function testEvent()
+    public function testEvent(): void
     {
         $testSuite = new TestSuite();
         $event = new TestSuiteFinishedEvent('some-uuid');

--- a/test/Yandex/Allure/Adapter/Event/TestSuiteStartedEventTest.php
+++ b/test/Yandex/Allure/Adapter/Event/TestSuiteStartedEventTest.php
@@ -11,7 +11,7 @@ use Yandex\Allure\Adapter\Model\TestSuite;
 
 class TestSuiteStartedEventTest extends TestCase
 {
-    public function testEvent()
+    public function testEvent(): void
     {
         $testSuite = new TestSuite();
         $testSuiteName = 'test-suite-name';

--- a/test/Yandex/Allure/Adapter/Model/ConstantCheckerTest.php
+++ b/test/Yandex/Allure/Adapter/Model/ConstantCheckerTest.php
@@ -8,9 +8,9 @@ use Yandex\Allure\Adapter\Model\Fixtures\TestConstants;
 
 class ConstantCheckerTest extends TestCase
 {
-    const CLASS_NAME = 'Yandex\Allure\Adapter\Model\Fixtures\TestConstants';
+    private const CLASS_NAME = 'Yandex\Allure\Adapter\Model\Fixtures\TestConstants';
 
-    public function testConstantIsPresent()
+    public function testConstantIsPresent(): void
     {
         $this->assertEquals(
             TestConstants::TEST_CONSTANT,
@@ -18,11 +18,9 @@ class ConstantCheckerTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \Yandex\Allure\Adapter\AllureException
-     */
-    public function testConstantIsMissing()
+    public function testConstantIsMissing(): void
     {
+        $this->expectException(AllureException::class);
         ConstantChecker::validate(self::CLASS_NAME, 'missing-value');
     }
 }

--- a/test/Yandex/Allure/Adapter/Model/Fixtures/TestConstants.php
+++ b/test/Yandex/Allure/Adapter/Model/Fixtures/TestConstants.php
@@ -4,5 +4,5 @@ namespace Yandex\Allure\Adapter\Model\Fixtures;
 
 class TestConstants
 {
-    const TEST_CONSTANT = 'test-value';
+    public const TEST_CONSTANT = 'test-value';
 }

--- a/test/Yandex/Allure/Adapter/Support/AttachmentSupportTest.php
+++ b/test/Yandex/Allure/Adapter/Support/AttachmentSupportTest.php
@@ -11,7 +11,7 @@ class AttachmentSupportTest extends TestCase
 {
     use AttachmentSupport;
 
-    public function testAddAttachment()
+    public function testAddAttachment(): void
     {
         $attachmentContents = 'test-contents';
         $attachmentCaption = 'test-title';

--- a/test/Yandex/Allure/Adapter/Support/MockedLifecycle.php
+++ b/test/Yandex/Allure/Adapter/Support/MockedLifecycle.php
@@ -24,10 +24,7 @@ class MockedLifecycle extends Allure
         $this->events[] = $event;
     }
 
-    /**
-     * @return array
-     */
-    public function getEvents()
+    public function getEvents(): array
     {
         return $this->events;
     }

--- a/test/Yandex/Allure/Adapter/Support/StepSupportTest.php
+++ b/test/Yandex/Allure/Adapter/Support/StepSupportTest.php
@@ -5,6 +5,7 @@ namespace Yandex\Allure\Adapter\Support;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Yandex\Allure\Adapter\Allure;
+use Yandex\Allure\Adapter\AllureException;
 use Yandex\Allure\Adapter\Event\StepFailedEvent;
 use Yandex\Allure\Adapter\Event\StepFinishedEvent;
 use Yandex\Allure\Adapter\Event\StepStartedEvent;
@@ -13,8 +14,8 @@ class StepSupportTest extends TestCase
 {
     use StepSupport;
 
-    const STEP_NAME = 'step-name';
-    const STEP_TITLE = 'step-title';
+    private const STEP_NAME = 'step-name';
+    private const STEP_TITLE = 'step-title';
 
     /**
      * @var \Yandex\Allure\Adapter\Support\MockedLifecycle
@@ -27,7 +28,7 @@ class StepSupportTest extends TestCase
         parent::__construct();
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->mockedLifecycle = new MockedLifecycle();
@@ -35,7 +36,7 @@ class StepSupportTest extends TestCase
         Allure::setLifecycle($this->getMockedLifecycle());
     }
 
-    public function testExecuteStepCorrectly()
+    public function testExecuteStepCorrectly(): void
     {
         $logicWithNoException = function () {
             //We do nothing, hence no error
@@ -47,14 +48,12 @@ class StepSupportTest extends TestCase
         $this->assertTrue($events[1] instanceof StepFinishedEvent);
     }
 
-    /**
-     * @expectedException Exception
-     */
     public function testExecuteFailingStep()
     {
         $logicWithException = function () {
             throw new Exception();
         };
+        $this->expectException(Exception::class);
         $this->executeStep(self::STEP_NAME, $logicWithException, self::STEP_TITLE);
         $events = $this->getMockedLifecycle()->getEvents();
         $this->assertEquals(3, sizeof($events));
@@ -63,24 +62,19 @@ class StepSupportTest extends TestCase
         $this->assertTrue($events[2] instanceof StepFinishedEvent);
     }
 
-    /**
-     * @expectedException \Yandex\Allure\Adapter\AllureException
-     */
     public function testExecuteStepWithMissingData()
     {
+        $this->expectException(AllureException::class);
         $this->executeStep(null, null, null);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         Allure::setDefaultLifecycle();
     }
 
-    /**
-     * @return MockedLifecycle
-     */
-    private function getMockedLifecycle()
+    private function getMockedLifecycle(): MockedLifecycle
     {
         return $this->mockedLifecycle;
     }

--- a/test/Yandex/Allure/Adapter/Support/UtilsTest.php
+++ b/test/Yandex/Allure/Adapter/Support/UtilsTest.php
@@ -8,14 +8,14 @@ class UtilsTest extends TestCase
 {
     use Utils;
 
-    public function testGetTimestamp()
+    public function testGetTimestamp(): void
     {
         $timestamp = self::getTimestamp();
         $this->assertTrue(is_float($timestamp));
         $this->assertGreaterThan(0, $timestamp);
     }
 
-    public function testGenerateUUID()
+    public function testGenerateUUID(): void
     {
         $uuid1 = self::generateUUID();
         $uuid2 = self::generateUUID();


### PR DESCRIPTION
This is a necessary evil to move forward and fix #61, I guess.

- We require `symfony/mime` to get rid of ugly hacks to make library run in modern environments. Version 4.3 requires PHP 7.1.3 or newer, and version 5 is supported, too.
- After removing workarounds we don't need `symfony/http-foundation` anymore. No other changes made to library's code, so backward compatibility is preserved. This code can be released as 1.* without breaking any clients, Composer will take care of dependency compatibilities.
- PHPUnit is upgraded to versions 8/9. Version 9.3 uses new `phpunit.xml` structure, so I've created `phpunit.legacy.xml` to use with older PHPUnit versions.
- Tests are now run on a range of PHP versions between 7.1.3 and 8.0.
